### PR TITLE
Update docs re superuser often needed for shared library installation

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,9 @@
       <div class="feature span3">
         <h2 class="callout">No privileged code. No daemon.</h2>
         <p>You don't need to be the superuser to install or run
-        Mosh. The client and server are executables run by an
+        Mosh (although many platforms require shared dynamically-linked
+	libraries that require superuser access to install).
+	The client and server are executables run by an
         ordinary user and last only for the life of the
         connection.</p>
       </div>


### PR DESCRIPTION
Update docs to explain that some superuser access is likely to be required in most installation scenarios, as highlighted by https://github.com/mobile-shell/mosh/issues/188 .  This is due to the dependency of binaries on dynamically-linked shared libraries, which are unlikely to be all pre-installed on most platforms, and will require superuser access to be installed.  That is until/unless there is a statically-linked option for most server/client on some platforms.